### PR TITLE
Data write verification and code cleanup

### DIFF
--- a/Assets/Nessie/Udon/NUSaveState/Scripts/U#/NUSaveState.asset
+++ b/Assets/Nessie/Udon/NUSaveState/Scripts/U#/NUSaveState.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: NUSaveState
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: b392fdc6e92842240ada9c2fe589f520,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: de073ea950ae555408a6dd464a6793f8,
     type: 2}
   udonAssembly: 
   assemblyError: 

--- a/Assets/Nessie/Udon/NUSaveState/Scripts/U#/NUSaveState.asset
+++ b/Assets/Nessie/Udon/NUSaveState/Scripts/U#/NUSaveState.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: NUSaveState
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: de073ea950ae555408a6dd464a6793f8,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: b392fdc6e92842240ada9c2fe589f520,
     type: 2}
   udonAssembly: 
   assemblyError: 
@@ -43,7 +43,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 42
+      Data: 43
     - Name: 
       Entry: 7
       Data: 
@@ -2099,7 +2099,7 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _currentBufferIndex
+      Data: failReason
     - Name: $v
       Entry: 7
       Data: 132|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
@@ -2108,7 +2108,7 @@ MonoBehaviour:
       Data: 133|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
-      Data: 44
+      Data: 8
     - Name: declarationType
       Entry: 3
       Data: 2
@@ -2117,13 +2117,13 @@ MonoBehaviour:
       Data: 0
     - Name: symbolResolvedTypeName
       Entry: 1
-      Data: SystemInt32
+      Data: SystemString
     - Name: symbolOriginalName
       Entry: 1
-      Data: _currentBufferIndex
+      Data: failReason
     - Name: symbolUniqueName
       Entry: 1
-      Data: _currentBufferIndex
+      Data: failReason
     - Name: symbolDefaultValue
       Entry: 6
       Data: 
@@ -2136,6 +2136,70 @@ MonoBehaviour:
         mscorlib
     - Name: 
       Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 135|System.NonSerializedAttribute, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: userBehaviourSource
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _currentBufferIndex
+    - Name: $v
+      Entry: 7
+      Data: 136|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: fieldSymbol
+      Entry: 7
+      Data: 137|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+    - Name: internalType
+      Entry: 9
+      Data: 44
+    - Name: declarationType
+      Entry: 3
+      Data: 2
+    - Name: syncMode
+      Entry: 3
+      Data: 0
+    - Name: symbolResolvedTypeName
+      Entry: 1
+      Data: SystemInt32
+    - Name: symbolOriginalName
+      Entry: 1
+      Data: _currentBufferIndex
+    - Name: symbolUniqueName
+      Entry: 1
+      Data: _currentBufferIndex
+    - Name: symbolDefaultValue
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: fieldAttributes
+      Entry: 7
+      Data: 138|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
       Data: 0
     - Name: 
       Entry: 13
@@ -2160,10 +2224,10 @@ MonoBehaviour:
       Data: _tempBuffer
     - Name: $v
       Entry: 7
-      Data: 135|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 139|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 136|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 140|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
       Data: 87
@@ -2190,7 +2254,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 137|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 141|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12
@@ -2218,10 +2282,10 @@ MonoBehaviour:
       Data: _currentBoolIndex
     - Name: $v
       Entry: 7
-      Data: 138|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 142|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 139|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 143|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
       Data: 44
@@ -2248,7 +2312,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 140|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 144|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12
@@ -2276,10 +2340,10 @@ MonoBehaviour:
       Data: _boolBuffer
     - Name: $v
       Entry: 7
-      Data: 141|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 145|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 142|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 146|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
       Data: 87
@@ -2298,70 +2362,6 @@ MonoBehaviour:
     - Name: symbolUniqueName
       Entry: 1
       Data: _boolBuffer
-    - Name: symbolDefaultValue
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: fieldAttributes
-      Entry: 7
-      Data: 143|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
-        mscorlib
-    - Name: 
-      Entry: 12
-      Data: 0
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: userBehaviourSource
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: _FLOAT_SIGN_BIT
-    - Name: $v
-      Entry: 7
-      Data: 144|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: fieldSymbol
-      Entry: 7
-      Data: 145|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
-    - Name: internalType
-      Entry: 7
-      Data: 146|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: System.UInt32, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: declarationType
-      Entry: 3
-      Data: 258
-    - Name: syncMode
-      Entry: 3
-      Data: 0
-    - Name: symbolResolvedTypeName
-      Entry: 1
-      Data: SystemUInt32
-    - Name: symbolOriginalName
-      Entry: 1
-      Data: _FLOAT_SIGN_BIT
-    - Name: symbolUniqueName
-      Entry: 1
-      Data: _FLOAT_SIGN_BIT
     - Name: symbolDefaultValue
       Entry: 6
       Data: 
@@ -2395,7 +2395,7 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _FLOAT_EXP_MASK
+      Data: _FLOAT_SIGN_BIT
     - Name: $v
       Entry: 7
       Data: 148|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
@@ -2403,8 +2403,72 @@ MonoBehaviour:
       Entry: 7
       Data: 149|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
+      Entry: 7
+      Data: 150|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.UInt32, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: declarationType
+      Entry: 3
+      Data: 258
+    - Name: syncMode
+      Entry: 3
+      Data: 0
+    - Name: symbolResolvedTypeName
+      Entry: 1
+      Data: SystemUInt32
+    - Name: symbolOriginalName
+      Entry: 1
+      Data: _FLOAT_SIGN_BIT
+    - Name: symbolUniqueName
+      Entry: 1
+      Data: _FLOAT_SIGN_BIT
+    - Name: symbolDefaultValue
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: fieldAttributes
+      Entry: 7
+      Data: 151|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: userBehaviourSource
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _FLOAT_EXP_MASK
+    - Name: $v
+      Entry: 7
+      Data: 152|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: fieldSymbol
+      Entry: 7
+      Data: 153|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+    - Name: internalType
       Entry: 9
-      Data: 146
+      Data: 150
     - Name: declarationType
       Entry: 3
       Data: 258
@@ -2428,7 +2492,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 150|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 154|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12
@@ -2456,13 +2520,13 @@ MonoBehaviour:
       Data: _FLOAT_FRAC_MASK
     - Name: $v
       Entry: 7
-      Data: 151|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 155|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 152|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 156|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
-      Data: 146
+      Data: 150
     - Name: declarationType
       Entry: 3
       Data: 258
@@ -2478,70 +2542,6 @@ MonoBehaviour:
     - Name: symbolUniqueName
       Entry: 1
       Data: _FLOAT_FRAC_MASK
-    - Name: symbolDefaultValue
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: fieldAttributes
-      Entry: 7
-      Data: 153|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
-        mscorlib
-    - Name: 
-      Entry: 12
-      Data: 0
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: userBehaviourSource
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: _DOUBLE_SIGN_BIT
-    - Name: $v
-      Entry: 7
-      Data: 154|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: fieldSymbol
-      Entry: 7
-      Data: 155|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
-    - Name: internalType
-      Entry: 7
-      Data: 156|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: System.UInt64, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: declarationType
-      Entry: 3
-      Data: 258
-    - Name: syncMode
-      Entry: 3
-      Data: 0
-    - Name: symbolResolvedTypeName
-      Entry: 1
-      Data: SystemUInt64
-    - Name: symbolOriginalName
-      Entry: 1
-      Data: _DOUBLE_SIGN_BIT
-    - Name: symbolUniqueName
-      Entry: 1
-      Data: _DOUBLE_SIGN_BIT
     - Name: symbolDefaultValue
       Entry: 6
       Data: 
@@ -2575,7 +2575,7 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _DOUBLE_EXP_MASK
+      Data: _DOUBLE_SIGN_BIT
     - Name: $v
       Entry: 7
       Data: 158|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
@@ -2583,8 +2583,72 @@ MonoBehaviour:
       Entry: 7
       Data: 159|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
+      Entry: 7
+      Data: 160|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.UInt64, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: declarationType
+      Entry: 3
+      Data: 258
+    - Name: syncMode
+      Entry: 3
+      Data: 0
+    - Name: symbolResolvedTypeName
+      Entry: 1
+      Data: SystemUInt64
+    - Name: symbolOriginalName
+      Entry: 1
+      Data: _DOUBLE_SIGN_BIT
+    - Name: symbolUniqueName
+      Entry: 1
+      Data: _DOUBLE_SIGN_BIT
+    - Name: symbolDefaultValue
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: fieldAttributes
+      Entry: 7
+      Data: 161|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: userBehaviourSource
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _DOUBLE_EXP_MASK
+    - Name: $v
+      Entry: 7
+      Data: 162|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: fieldSymbol
+      Entry: 7
+      Data: 163|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+    - Name: internalType
       Entry: 9
-      Data: 156
+      Data: 160
     - Name: declarationType
       Entry: 3
       Data: 258
@@ -2608,7 +2672,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 160|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 164|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12
@@ -2636,13 +2700,13 @@ MonoBehaviour:
       Data: _DOUBLE_FRAC_MASK
     - Name: $v
       Entry: 7
-      Data: 161|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 165|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 162|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 166|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
-      Data: 156
+      Data: 160
     - Name: declarationType
       Entry: 3
       Data: 258
@@ -2666,7 +2730,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 163|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 167|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12

--- a/Assets/Nessie/Udon/NUSaveState/Scripts/U#/NUSaveState.cs
+++ b/Assets/Nessie/Udon/NUSaveState/Scripts/U#/NUSaveState.cs
@@ -369,7 +369,7 @@ namespace Nessie.Udon.SaveState
                     LogError($"Data verification failed at index {i}: {inputData[i]:X2} doesn't match {writtenData[i]:X2}! Write should be restarted!");
                     failReason = $"Data verification failed at index {i}: {inputData[i]:X2} doesn't match {writtenData[i]:X2}";
                     _FailedData();
-                    break;
+                    return;
                 }
             }
 
@@ -378,11 +378,11 @@ namespace Nessie.Udon.SaveState
                 dataProgress = (float)(dataByteIndex + avatarByteOffset) / bufferByteCount;
 
                 dataAvatarIndex++;
-                SendCustomEventDelayedFrames(nameof(_ChangeAvatar), 10);
+                _ChangeAvatar();
             }
             else
             {
-                SendCustomEventDelayedFrames(nameof(_FinishedData), 10);
+                _FinishedData();
             }
         }
 

--- a/Assets/Nessie/Udon/NUSaveState/Scripts/U#/NUSaveState.cs
+++ b/Assets/Nessie/Udon/NUSaveState/Scripts/U#/NUSaveState.cs
@@ -126,6 +126,8 @@ namespace Nessie.Udon.SaveState
                 return Progress;
             }
         }
+        
+        [NonSerialized] public string failReason;
 
         #endregion Public Fields
 
@@ -139,16 +141,16 @@ namespace Nessie.Udon.SaveState
 
             // Validation.
             if (parameterWriters.Length < 1)
-                Debug.LogError("[<color=#00FF9F>SaveState</color>] NUSaveState is missing animator controllers.");
+                LogError("NUSaveState is missing animator controllers.");
 
             if (dataAvatarIDs.Length < avatarCount)
-                Debug.LogError("[<color=#00FF9F>SaveState</color>] NUSaveState is missing avatar blueprints.");
+                LogError("NUSaveState is missing avatar blueprints.");
 
             if (dataKeyCoords.Length < avatarCount)
-                Debug.LogError("[<color=#00FF9F>SaveState</color>] NUSaveState is missing key coordinates.");
+                LogError("NUSaveState is missing key coordinates.");
 
             if (gameObject.layer != 5)
-                Debug.LogError("[<color=#00FF9F>SaveState</color>] NUSaveState behaviour is not situated on the UI layer.");
+                LogError("NUSaveState behaviour is not situated on the UI layer.");
 
             inputBytes = new byte[bufferByteCount];
             outputBytes = new byte[bufferByteCount];
@@ -186,7 +188,7 @@ namespace Nessie.Udon.SaveState
         {
             if (avatarIsLoading)
             {
-                Debug.Log($"[<color=#00FF9F>SaveState</color>] Detected buffer avatar: {dataAvatarIndex}");
+                Log($"Detected buffer avatar: {dataAvatarIndex}");
 
                 avatarCurrentDuration = 0f;
                 avatarIsLoading = false;
@@ -221,8 +223,8 @@ namespace Nessie.Udon.SaveState
 
             dataStatus = 1;
 
-            _PackData();
-
+            inputBytes = _PackData();
+            
             dataWriter.transform.SetPositionAndRotation(localPlayer.GetPosition(), localPlayer.GetRotation()); // Put user in station to prevent movement and set the velocity parameters to 0.
             dataWriter.animatorController = null;
             dataWriter.UseStation(localPlayer);
@@ -260,7 +262,7 @@ namespace Nessie.Udon.SaveState
         {
             dataByteIndex = 0;
 
-            Debug.Log($"[<color=#00FF9F>SaveState</color>] Switching avatar to buffer avatar: {dataAvatarIndex}.");
+            Log($"Switching avatar to buffer avatar: {dataAvatarIndex}.");
             dataAvatarPedestals[dataAvatarIndex].SetAvatarUse(localPlayer);
 
             avatarCurrentDuration = avatarTimeoutDuration;
@@ -282,7 +284,8 @@ namespace Nessie.Udon.SaveState
                 }
                 else
                 {
-                    Debug.LogError("[<color=#00FF9F>SaveState</color>] Data avatar took too long to load or avatar ID is mismatched.");
+                    LogError("Data avatar took too long to load or avatar ID is mismatched.");
+                    failReason = "Data avatar took too long to load or avatar ID is mismatched.";
                     _FailedData();
                 }
             }
@@ -312,6 +315,8 @@ namespace Nessie.Udon.SaveState
 
         public void _SetData() // Write data by doing float additions.
         {
+            //Log($"Writing data for avatar {dataAvatarIndex}: data byte index {dataByteIndex}");
+            
             int avatarByteOffset = dataAvatarIndex * 32;
             int avatarByteCount = Mathf.Min(bufferByteCount - avatarByteOffset, 32);
 
@@ -328,7 +333,7 @@ namespace Nessie.Udon.SaveState
 
             //string debugBits = $"{Convert.ToString(byte1, 2).PadLeft(8, '0')}, {Convert.ToString(byte2, 2).PadLeft(8, '0')}, {Convert.ToString(byte3, 2).PadLeft(8, '0')}";
             //string debugVels = $"{newVelocity.x}, {newVelocity.y}, {newVelocity.z}";
-            //Debug.Log($"[<color=#00FF9F>SaveState</color>] Batch {Mathf.CeilToInt(dataByteIndex / 3f)}: {debugBits} : {debugVels}");
+            //Log($"Batch {Mathf.CeilToInt(dataByteIndex / 3f)}: {debugBits} : {debugVels}");
 
             if (dataByteIndex < avatarByteCount)
             {
@@ -338,37 +343,59 @@ namespace Nessie.Udon.SaveState
             }
             else
             {
-                if (dataByteIndex + avatarByteOffset < bufferByteCount)
-                {
-                    dataProgress = (float)(dataByteIndex + avatarByteOffset) / bufferByteCount;
+                SendCustomEventDelayedFrames(nameof(_VerifyData), 10, VRC.Udon.Common.Enums.EventTiming.LateUpdate);
+            }
+        }
 
-                    dataAvatarIndex++;
-                    SendCustomEventDelayedFrames(nameof(_ChangeAvatar), 10);
-                }
-                else
+        /// <summary>
+        /// Verifies if the written data matches the input data. If succesful, queues the next write or finishes write operation.
+        /// </summary>
+        public void _VerifyData()
+        {
+            int avatarByteOffset = dataAvatarIndex * 32;
+            int avatarByteCount = Mathf.Min(bufferByteCount - avatarByteOffset, 32);
+            
+            //verify if the write was succesful
+            byte[] inputData = new byte[avatarByteCount];
+            Array.Copy(inputBytes, avatarByteOffset, inputData, 0, avatarByteCount);
+
+            byte[] writtenData = _GetAvatarBytes();
+
+            //compare
+            for (int i = 0; i < inputData.Length; i++)
+            {
+                if (inputData[i] != writtenData[i])
                 {
-                    SendCustomEventDelayedFrames(nameof(_FinishedData), 10);
+                    LogError($"Data verification failed at index {i}: {inputData[i]:X2} doesn't match {writtenData[i]:X2}! Write should be restarted!");
+                    failReason = $"Data verification failed at index {i}: {inputData[i]:X2} doesn't match {writtenData[i]:X2}";
+                    _FailedData();
+                    break;
                 }
+            }
+
+            if (dataByteIndex + avatarByteOffset < bufferByteCount)
+            {
+                dataProgress = (float)(dataByteIndex + avatarByteOffset) / bufferByteCount;
+
+                dataAvatarIndex++;
+                SendCustomEventDelayedFrames(nameof(_ChangeAvatar), 10);
+            }
+            else
+            {
+                SendCustomEventDelayedFrames(nameof(_FinishedData), 10);
             }
         }
 
         public void _GetData() // Read data using finger rotations.
         {
             int avatarByteOffset = dataAvatarIndex * 32;
-            int avatarByteCount = Mathf.Min(bufferByteCount - avatarByteOffset, 32);
-
-            for (int boneIndex = 0; dataByteIndex < avatarByteCount; boneIndex++)
-            {
-                Quaternion muscleTarget = localPlayer.GetBoneRotation((HumanBodyBones)dataBones[boneIndex]);
-                Quaternion muscleParent = localPlayer.GetBoneRotation((HumanBodyBones)dataBones[boneIndex + 8]);
-
-                int bytes = Mathf.RoundToInt(_InverseMuscle(muscleTarget, muscleParent) * 65536) & 0xFFFF; // 2 bytes per parameter.
-                outputBytes[dataByteIndex++ + avatarByteOffset] = (byte)(bytes & 0xFF);
-                if (dataByteIndex < avatarByteCount)
-                    outputBytes[dataByteIndex++ + avatarByteOffset] = (byte)(bytes >> 8);
-            }
-
-            if (dataByteIndex + avatarByteOffset < bufferByteCount)
+            
+            byte[] data = _GetAvatarBytes();
+            
+            //copy output data into outputBytes array
+            Array.Copy(data, 0, outputBytes, avatarByteOffset, data.Length);
+            
+            if (avatarByteOffset + data.Length < bufferByteCount)
             {
                 dataProgress = (float)avatarByteOffset / bufferByteCount;
 
@@ -381,6 +408,33 @@ namespace Nessie.Udon.SaveState
             }
         }
 
+        /// <summary>
+        /// Returns byte array containing current avatar data
+        /// </summary>
+        public byte[] _GetAvatarBytes()
+        {
+            int avatarByteOffset = dataAvatarIndex * 32;
+            int avatarByteCount = Mathf.Min(bufferByteCount - avatarByteOffset, 32);
+
+            byte[] output = new byte[avatarByteCount];
+            
+            int byteIndex = 0;
+            
+            for (int boneIndex = 0; byteIndex < avatarByteCount; boneIndex++)
+            {
+                Quaternion muscleTarget = localPlayer.GetBoneRotation((HumanBodyBones)dataBones[boneIndex]);
+                Quaternion muscleParent = localPlayer.GetBoneRotation((HumanBodyBones)dataBones[boneIndex + 8]);
+
+                int bytes = Mathf.RoundToInt(_InverseMuscle(muscleTarget, muscleParent) * 65536) & 0xFFFF; // 2 bytes per parameter.
+
+                output[byteIndex++] = (byte)(bytes & 0xFF);
+                if (byteIndex < avatarByteCount)
+                    output[byteIndex++] = (byte)(bytes >> 8);
+            }
+
+            return output;
+        }
+
         public void _FinishedData()
         {
             dataProgress = 1;
@@ -390,13 +444,14 @@ namespace Nessie.Udon.SaveState
                 dataWriter.ExitStation(localPlayer); // Only exit the station once the last animator states have been reached.
                 localPlayer.Immobilize(false);
 
-                Debug.Log($"[<color=#00FF9F>SaveState</color>] Data has been saved.");
+                Log("Data has been saved.");
             }
             else
             {
-                _UnpackData();
+                byte[] bufferBytes = __PrepareReadBuffer(outputBytes);
+                _UnpackData(bufferBytes);
 
-                Debug.Log("[<color=#00FF9F>SaveState</color>] Data has been loaded.");
+                Log("Data has been loaded.");
             }
 
             _SSCallback();
@@ -425,31 +480,35 @@ namespace Nessie.Udon.SaveState
             dataStatus = 0;
         }
 
-        private void _PackData()
+        /// <summary>
+        /// Returns packed version of input data as byte array
+        /// </summary>
+        private byte[] _PackData()
         {
             int bufferLength = 0;
             byte[] bufferBytes = __PrepareWriteBuffer();
 
             for (int i = 0; i < bufferUdonBehaviours.Length; i++) 
             {
-                if (bufferUdonBehaviours[i] == null || bufferVariables[i] == null) return;
+                if (bufferUdonBehaviours[i] == null || bufferVariables[i] == null) return new byte[bufferLength];
 
                 object value = ((UdonBehaviour)bufferUdonBehaviours[i]).GetProgramVariable(bufferVariables[i]);
                 bufferLength = __WriteBufferTypedObject(value, bufferTypes[i], bufferBytes, bufferLength);
             }
 
-            for (int i = 0; i < _boolBuffer.Length; i++) // Append the bools at the end of the buffer.
+            foreach (byte t in _boolBuffer)
             {
-                bufferLength = __WriteBufferByte(_boolBuffer[i], bufferBytes, bufferLength);
+                bufferLength = __WriteBufferByte(t, bufferBytes, bufferLength);
             }
 
-            inputBytes = __FinalizeWriteBuffer(bufferBytes, bufferLength);
+            return __FinalizeWriteBuffer(bufferBytes, bufferLength);
         }
 
-        private void _UnpackData()
+        /// <summary>
+        /// Writes back bufferBytes from avatar to target behaviours
+        /// </summary>
+        private void _UnpackData(byte[] bufferBytes)
         {
-            byte[] bufferBytes = __PrepareReadBuffer(outputBytes);
-
             Array.Copy(bufferBytes, bufferBytes.Length - _boolBuffer.Length, _boolBuffer, 0, _boolBuffer.Length); // Pull bools from the end of the buffer.
 
             for (int i = 0; i < bufferUdonBehaviours.Length; i++)
@@ -472,6 +531,16 @@ namespace Nessie.Udon.SaveState
 
         #endregion SaveState Data
 
+        private void Log(string log)
+        {
+            Debug.Log($"[<color=#00FF9F>SaveState</color>] {log}");
+        }
+        
+        private void LogError(string log)
+        {
+            Debug.LogError($"[<color=#00FF9F>SaveState</color>] {log}");
+        }
+        
         #region Buffer Utilities
 
         // Thank you Genesis for the bit converter code!
@@ -494,7 +563,7 @@ namespace Nessie.Udon.SaveState
 
         private byte[] __FinalizeWriteBuffer(byte[] buffer, int length)
         {
-            var finalBuffer = new byte[length];
+            byte[] finalBuffer = new byte[length];
             Array.Copy(buffer, finalBuffer, length);
             return finalBuffer;
         }


### PR DESCRIPTION
After each avatar write, the written data is then verified to make sure the correct data was written.
Any time a failure happens, a string will be written to failReason containing the cause, which can be read right after a fail event gets called.